### PR TITLE
refactor!: Migrate to baseline rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Compatible browsers
 
-You can check compatible browsers on [browsersl.ist](https://browsersl.ist/#q=last%203%20years%20and%20fully%20supports%20es6%20and%20%3E%200.05%25%0Anot%20dead%0Anot%20op_mini%20all%0Anot%20and_qq%20%3E%200%0Anot%20and_uc%20%3E%200%0AFirefox%20ESR%0AFirefox%20%3E%200%20and%20last%203%20years%20and%20%3E%200.01%25).
+You can check compatible browsers on [browsersl.ist](https://browsersl.ist/#q=baseline%20widely%20available%20on%202025-01-01%20with%20downstream).
 
 ## Install
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,1 @@
-export = [
-    'last 3 years and fully supports es6 and > 0.05%',
-    'not dead',
-    'not op_mini all',
-    'not and_qq > 0',
-    'not and_uc > 0',
-    'Firefox ESR',
-    'Firefox > 0 and last 3 years and > 0.01%',
-];
+export = ['baseline widely available on 2025-01-01 with downstream'];


### PR DESCRIPTION
We are switching to a new approach using `baseline`. It is more versatile and error-resistant.